### PR TITLE
Docs (Chore) Review all Slash GraphQL docs for typos, fix formatting/usage issues encountered

### DIFF
--- a/content/admin/clone.md
+++ b/content/admin/clone.md
@@ -7,11 +7,11 @@ weight = 7
 
 Cloning a backend allows making a copy of an existing backend. The clone will be created with all the data and schema of the original backend present at the time of cloning. The clone will have its own endpoint and will be independent of the original backend once it is created. Any further changes in either backends will not reflect in the other. Currently, a clone can only be created in the same zone as that of the original backend.
 
-In order to clone your backend, click on the `Clone Backend` button under the [Settings](https://slash.dgraph.io/_/settings) tab in the dashboard's sidebar.
+In order to clone your backend, click on the **Clone Backend** button under the [Settings](https://slash.dgraph.io/_/settings) tab in the dashboard's sidebar.
 
 You can also clone using the [Slash GraphQL CLI](https://www.npmjs.com/package/slash-graphql) as a two step process.
 
 1. Create a new backend.
 2. Restore data into the new backend from the original backend.
 
-You can also perform the restore operation on an existing backend if you have an unused backend or want to resuse an existing endpoint. But note that the restore operation will drop all the existing data along with schema on the current backedn and replace it with the original backend's data and schema.
+You can also perform the restore operation on an existing backend if you have an unused backend or want to reuse an existing endpoint. But note that the restore operation will drop all the existing data along with schema on the current backend and replace it with the original backend's data and schema.

--- a/content/admin/drop-data.md
+++ b/content/admin/drop-data.md
@@ -9,9 +9,9 @@ It is possible to drop all data from your Slash GraphQL backend, and start afres
 
 In order to drop all data while retaining the schema, please click the `Drop Data` button under the [Settings](https://slash.dgraph.io/_/settings) tab in the sidebar.
 
-### Dropping Data Programatically
+### Dropping Data Programmatically
 
-In order to do this, call the `dropData` mutation on `/admin/slash`. As an example, if your graphql endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
+In order to do this, call the `dropData` mutation on `/admin/slash`. As an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
 
 Please note that this endpoint requires [Authentication](/admin/authentication).
 

--- a/content/admin/import-export.md
+++ b/content/admin/import-export.md
@@ -9,7 +9,7 @@ It is possible to export your data from one slash backend, and then import this 
 
 ## Exporting Data
 
-It is possible to export your data via a JSON format. In order to do this, call the `export` mutation on `/admin/slash`. As an example, if your graphql endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
+It is possible to export your data via a JSON format. In order to do this, call the `export` mutation on `/admin/slash`. As an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
 
 Please note that this endpoint requires [Authentication](/admin/authentication).
 
@@ -36,7 +36,7 @@ Export will usually return 3 files:
 It is possible to import data into a Slash GraphQL backend using [live loader](https://dgraph.io/docs/deploy/#live-loader). In order to import data, do the following steps
 
 1. First import your schema into your Slash GraphQL backend, using either the [Schema API](/admin/schema) or via [the Schema Page](https://slash.dgraph.io/_/schema).
-2. Find the gRPC endpoint for your cluster, as described in the [advanced queries](/advanced-queries) section. This will look like frozen-mango-42.grpc.us-west-1.aws.cloud.dgraph.io:443
+2. Find the gRPC endpoint for your cluster, as described in the [advanced queries](/advanced-queries) section. This will look like **frozen-mango-42.grpc.us-west-1.aws.cloud.dgraph.io:443**
 3. Run the live loader as follows. Do note that running this via docker requires you to use an unreleased tag (either master or v20.07-slash)
 
 ```

--- a/content/admin/overview.md
+++ b/content/admin/overview.md
@@ -10,13 +10,13 @@ weight = 1
 
 *These are draft docs for Slash GraphQL, which is currently in beta*
 
-Here is a guide to programatically administering your Slash GraphQL backend.
+Here is a guide to programmatically administering your Slash GraphQL backend.
 
 Wherever possible, we have maintained compatibility with the corresponding Dgraph API, with the additional step of requiring authentication via the 'X-Auth-Token' header.
 
 Please see the following topics:
 
 * [Authentication](/admin/authentication) will guide you in creating a API token. Since all admin APIs require an auth token, this is a good place to start.
-* [Schema](/admin/schema) describes how to programatically query and update your GraphQL schema.
+* [Schema](/admin/schema) describes how to programmatically query and update your GraphQL schema.
 * [Import and Exporting Data](/admin/import-export) is a guide for exporting your data from a Slash GraphQL backend, and how to import it into another cluster
 * [Dropping Data](/admin/drop-data) will guide you through dropping all data from your Slash GraphQL backend.

--- a/content/admin/overview.md
+++ b/content/admin/overview.md
@@ -8,8 +8,6 @@ weight = 1
     identifier = "slash-overview"
 +++
 
-*These are draft docs for Slash GraphQL, which is currently in beta*
-
 Here is a guide to programmatically administering your Slash GraphQL backend.
 
 Wherever possible, we have maintained compatibility with the corresponding Dgraph API, with the additional step of requiring authentication via the 'X-Auth-Token' header.

--- a/content/admin/schema.md
+++ b/content/admin/schema.md
@@ -5,7 +5,7 @@ weight = 3
     parent = "slash-graphql-admin"
 +++
 
-Your GraphQL schema can be fetched and updated using the `/admin` endpoint of your cluster. As an example, if your graphql endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin`.
+Your GraphQL schema can be fetched and updated using the `/admin` endpoint of your cluster. As an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin`.
 
 This endpoint works in a similar way to the [/admin](https://dgraph.io/docs/graphql/admin) endpoint of Dgraph, with the additional constraint of [requiring authentication](/admin/authentication).
 
@@ -23,7 +23,7 @@ It is possible to fetch your current schema using the `getGQLSchema` query on `/
 
 ### Setting a New Schema
 
-You can save a new schema using the `updateGQLSchema` mutation on `/admin`. Below is an example GraphQL body, with a variable called sch which must be passed in as a [variable](https://graphql.org/graphql-js/passing-arguments/)
+You can save a new schema using the `updateGQLSchema` mutation on `/admin`. Below is an example GraphQL body, with a variable called `sch` which must be passed in as a [variable](https://graphql.org/graphql-js/passing-arguments/)
 
 ```graphql
 mutation($sch: String!) {

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -10,9 +10,9 @@ weight = 1
 Please see the following topics:
 
 - The [QuickStart](/slash-quick-start) will help you get started with a Slash GraphQL Schema, starting with a multi tenant todo app
-- [Administering your Backend](/admin/overview) covers topics such as how to programatically set your schema, and import or export your data
+- [Administering your Backend](/admin/overview) covers topics such as how to programmatically set your schema, and import or export your data
   - [Authentication](/admin/authentication) will guide you in creating a API token. Since all admin APIs require an auth token, this is a good place to start.
-  - [Schema](/admin/schema) describes how to programatically query and update your GraphQL schema.
+  - [Schema](/admin/schema) describes how to programmatically query and update your GraphQL schema.
   - [Import and Exporting Data](/admin/import-export) is a guide for exporting your data from a Slash GraphQL backend, and how to import it into another cluster
   - [Dropping Data](/admin/drop-data) will guide you through dropping all data from your Slash GraphQL backend.
   - [Switching Backend Modes](/admin/backend-modes) will guide you through changing Slash GraphQL backend mode.

--- a/content/migrating-from-hosted-dgraph.md
+++ b/content/migrating-from-hosted-dgraph.md
@@ -5,10 +5,11 @@ weight = 7
     parent = "slash-graphql"
 +++
 
-Slash GraphQL and Slash Enterprise are compatible with majority of Dgraph features, and you can easily migrate your existing Dgraph app over to Slash.
+Slash GraphQL and Dgraph Cloud are compatible with majority of Dgraph features,
+and you can easily migrate your existing Dgraph app over to Slash.
 
-Here is how to get started
+To get started
 
-* Create a new backend. This can be done via the Slash GraphQL interface, or by using the [command line tool](https://www.npmjs.com/package/slash-graphql)
-* Switch your backend to [flexible mode](/admin/backend-modes#flexible-mode).
-* Connect to your backend with your favorite client. Please see [Connecting from Dgraph Clients](/advanced-queries#connecting-from-dgraph-clients)
+1. Create a new backend. This can be done via the Slash GraphQL interface, or by using the [command line tool](https://www.npmjs.com/package/slash-graphql)
+2. Switch your backend to [flexible mode](/admin/backend-modes#flexible-mode).
+3. Connect to your backend with your favorite client. Please see [Connecting from Dgraph Clients](/advanced-queries#connecting-from-dgraph-clients)

--- a/content/migrating-from-hosted-dgraph.md
+++ b/content/migrating-from-hosted-dgraph.md
@@ -11,5 +11,5 @@ and you can easily migrate your existing Dgraph app over to Slash.
 To get started
 
 1. Create a new backend. This can be done via the Slash GraphQL interface, or by using the [command line tool](https://www.npmjs.com/package/slash-graphql)
-2. Switch your backend to [flexible mode](/admin/backend-modes#flexible-mode).
+2. (optional) Switch your backend to [flexible mode](/admin/backend-modes#flexible-mode).
 3. Connect to your backend with your favorite client. Please see [Connecting from Dgraph Clients](/advanced-queries#connecting-from-dgraph-clients)

--- a/content/one-click-deploy.md
+++ b/content/one-click-deploy.md
@@ -19,7 +19,7 @@ If you wish to deploy your apps to your own domain, you can do that easily with 
 2. Link your forked repo to Netlify by Clicking `New Site from Git` and
    {{% load-img "images/importSite.png" "Import Site" %}}
 3. After successful import of the forked repository click on `Show advanced` and `New variable`.
-4. Add `REACT_APP_GRAPHQL_ENDPOINT` in the key and your graphql endpoint obtained from Slash GraphQL in the value field.
+4. Add `REACT_APP_GRAPHQL_ENDPOINT` in the key and your GraphQL endpoint obtained from Slash GraphQL in the value field.
 5. Click `Deploy Site` on Netlify Dashboard.
    {{% load-img "images/advanced-SettingsNetlify.png" "Advanced Settings" %}}
 6. You can configure [Auth0](https://auth0.com/) steps by following Authorization section of the blogpost [here.](https://dgraph.io/blog/post/surveyo-into/)

--- a/content/slash-cli/overview.md
+++ b/content/slash-cli/overview.md
@@ -7,8 +7,6 @@ weight = 1
     identifier = "Overview"
 +++
 
-*These are draft docs for Slash GraphQL, which is currently in beta*
-
 Slash GraphQL now includes a CLI so you can manage it from the comfort of your command line!
 
 Wherever possible, we have maintained compatibility with the corresponding Dgraph API, with the additional step of requiring authentication via the 'X-Auth-Token' header.


### PR DESCRIPTION
This PR fixes typographical errors noted by a reader of one of our pages, so I did a quick scan for typos. While fixing typos (those reported, and those detected by my editing tools), I noticed and fixed the following small doc issues:
- "graphql" references in sentences (I changed these to GraphQL)
- References to "beta" (removed) and references to Slash Enterprise (changed to Dgraph Cloud)
- Formatting errors that I noticed while making these changes (code formatting for UI, a variable without code formatting, etc.)

Please merge when approved :)
