### PR TITLE
docs: Fix typo on example endpoint names.

### DIFF
--- a/content/admin/drop-data.md
+++ b/content/admin/drop-data.md
@@ -11,7 +11,7 @@ In order to drop all data while retaining the schema, please click the `Drop Dat
 
 ### Dropping Data Programmatically
 
-In order to do this, call the `dropData` mutation on `/admin/slash`. As an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
+In order to do this, call the `dropData` mutation on `/admin/slash`. As an example, if your GraphQL endpoint is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
 
 Please note that this endpoint requires [Authentication](/admin/authentication).
 

--- a/content/admin/import-export.md
+++ b/content/admin/import-export.md
@@ -9,7 +9,7 @@ It is possible to export your data from one slash backend, and then import this 
 
 ## Exporting Data
 
-It is possible to export your data via a JSON format. In order to do this, call the `export` mutation on `/admin/slash`. As an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
+It is possible to export your data via a JSON format. In order to do this, call the `export` mutation on `/admin/slash`. As an example, if your GraphQL endpoint is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin/slash`.
 
 Please note that this endpoint requires [Authentication](/admin/authentication).
 
@@ -36,7 +36,7 @@ Export will usually return 3 files:
 It is possible to import data into a Slash GraphQL backend using [live loader](https://dgraph.io/docs/deploy/#live-loader). In order to import data, do the following steps
 
 1. First import your schema into your Slash GraphQL backend, using either the [Schema API](/admin/schema) or via [the Schema Page](https://slash.dgraph.io/_/schema).
-2. Find the gRPC endpoint for your cluster, as described in the [advanced queries](/advanced-queries) section. This will look like **frozen-mango-42.grpc.us-west-1.aws.cloud.dgraph.io:443**
+2. Find the gRPC endpoint for your cluster, as described in the [advanced queries](/advanced-queries) section. This will look like **frozen-mango.grpc.us-west-1.aws.cloud.dgraph.io:443**
 3. Run the live loader as follows. Do note that running this via docker requires you to use an unreleased tag (either master or v20.07-slash)
 
 ```

--- a/content/admin/schema.md
+++ b/content/admin/schema.md
@@ -5,7 +5,7 @@ weight = 3
     parent = "slash-graphql-admin"
 +++
 
-Your GraphQL schema can be fetched and updated using the `/admin` endpoint of your cluster. As an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin`.
+Your GraphQL schema can be fetched and updated using the `/admin` endpoint of your cluster. As an example, if your GraphQL endpoint is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/graphql`, then the admin endpoint for schema will be at `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/admin`.
 
 This endpoint works in a similar way to the [/admin](https://dgraph.io/docs/graphql/admin) endpoint of Dgraph, with the additional constraint of [requiring authentication](/admin/authentication).
 

--- a/content/advanced-queries.md
+++ b/content/advanced-queries.md
@@ -35,7 +35,7 @@ create an API token, please see [Authentication](/admin/authentication).
 ### HTTP
 
 You can query your backend with DQL using your cluster's `/query` endpoint. As
-an example, if your GraphQL endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`,
+an example, if your GraphQL endpoint is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/graphql`,
 then the admin endpoint for the schema is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/query`.
 
 You can also access the [`/mutate`](https://dgraph.io/docs/mutations/) and
@@ -86,7 +86,7 @@ Here is an example which uses the [pydgraph client](https://github.com/dgraph-io
 ```python
 import pydgraph
 
-client_stub = pydgraph.DgraphClientStub.from_slash_endpoint("https://frozen-mango-42.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>")
+client_stub = pydgraph.DgraphClientStub.from_slash_endpoint("https://frozen-mango.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>")
 client = pydgraph.DgraphClient(client_stub)
 ```
 
@@ -133,7 +133,7 @@ clients.
 ```python
 import pydgraph
 
-client_stub = pydgraph.DgraphClientStub.from_slash_endpoint("https://frozen-mango-42.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>")
+client_stub = pydgraph.DgraphClientStub.from_slash_endpoint("https://frozen-mango.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>")
 client = pydgraph.DgraphClient(client_stub)
 ```
 
@@ -142,7 +142,7 @@ client = pydgraph.DgraphClient(client_stub)
 const dgraph = require("dgraph-js");
 
 const clientStub = dgraph.clientStubFromSlashGraphQLEndpoint(
-  "https://frozen-mango-42.eu-central-1.aws.cloud.dgraph.io/graphql",
+  "https://frozen-mango.eu-central-1.aws.cloud.dgraph.io/graphql",
   "<api-key>"
 );
 const dgraphClient = new dgraph.DgraphClient(clientStub);
@@ -151,7 +151,7 @@ const dgraphClient = new dgraph.DgraphClient(clientStub);
 **Go**
 ```golang
 // This example uses dgo
-conn, err := dgo.DialSlashEndpoint("https://frozen-mango-42.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>")
+conn, err := dgo.DialSlashEndpoint("https://frozen-mango.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>")
 if err != nil {
   log.Fatal(err)
 }
@@ -162,7 +162,7 @@ dgraphClient := dgo.NewDgraphClient(api.NewDgraphClient(conn))
 **Java**
 ```java
 // This example uses dgraph4j
-DgraphStub stub = DgraphClient.clientStubFromSlashEndpoint("https://frozen-mango-42.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>");
+DgraphStub stub = DgraphClient.clientStubFromSlashEndpoint("https://frozen-mango.eu-central-1.aws.cloud.dgraph.io/graphql", "<api-key>");
 DgraphClient dgraphClient = new DgraphClient(stub);
 ```
 
@@ -174,7 +174,7 @@ Ratel yourself, or you can use Ratel online at [Dgraph Play](https://play.dgraph
 To configure Ratel:
 
 1. Click the Dgraph logo in the top left to bring up the connection screen (by default, it has the caption: play.dgraph.io)
-2. Enter your backend's host in the Dgraph Server URL field. This is obtained by removing `/graphql` from the end of your `/graphql` endpoint URL. For example, if your `/graphql` endpoint is `https://frozen-mango-42.us-west-2.aws.cloud.dgraph.io/graphql`, then the host for Ratel is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io`
+2. Enter your backend's host in the Dgraph Server URL field. This is obtained by removing `/graphql` from the end of your `/graphql` endpoint URL. For example, if your `/graphql` endpoint is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io/graphql`, then the host for Ratel is `https://frozen-mango.us-west-2.aws.cloud.dgraph.io`
 3. Click the **Connect** button. You should see a green check mark next to the word **Connected**.
 4. Click on the **Extra Settings** tab, and then enter your API token into the
  **Slash API Key** field. To create a new API token, see [Authentication](/admin/authentication).


### PR DESCRIPTION
Some doc sections incorrectly say that endpoints go to "frozen-mango-42"
and "frozen-mango" hosts. This fixes those doc sections by referring to
the right hostname.

1. The generated backend names don't usually contain number suffixes
2. I've opted to switch everything to "frozen-mango", which is both
   simpler, and is consistent with the example name that's used more
   commonly.