### PR TITLE
Improve docs around API Keys and Anonymous Access

### DIFF
--- a/content/admin/authentication.md
+++ b/content/admin/authentication.md
@@ -5,7 +5,7 @@ weight = 2
     parent = "slash-graphql-admin"
 +++
 
-All the APIs documented here require an API token for access. A new API token can be generated from Slash GraphQL by selecting the ["Settings" button](https://cloud.dgraph.io/_/settings) from the sidebar, then clicking the Add API Key button. Keep your API key safe, it will not be accessible once you leave the page.
+Administrating your Dgraph Cloud with the (Slash CLI)[slash-cli/overview/], using the `/query`, `/mutate`, `/commit`, `/admin`, `/admin/slash`, or `/alter` endpoints on Dgraph Cloud, and bypassing Anonymous Access restrictions on the `/graphql` endpoint requires an API key. A new API key can be generated from Slash GraphQL by selecting the ["Settings" button](https://cloud.dgraph.io/_/settings) from the sidebar, then clicking the Add API Key button. Keep your API key safe, it will not be accessible once you leave the page.
 
 ![Slash-GraphQL: Add an API Key ](/images/slash-graphql-4.png)
 
@@ -14,14 +14,18 @@ There are two types of API keys, client and admin.
 - **Client API keys** can only be used to perform query, mutation and commit operations.
 - **Admin API keys** can be used to perform both client operations and admin operations like drop data, destroy backend, update schema.
 
+{{% notice "note" %}}
+Either Client API keys or Admin API keys can be used to bypass (Anonymous Access)[../settings] restrictions.
+{{% /notice %}}
+
 ![Slash-GraphQL: Select API Key Role ](/images/slash-graphql-5.png)
 <br>
 <br>
-All admin API requests must be authenticated by passing the API token as the 'X-Auth-Token' header to every HTTP request. You can verify that your API token works by using the following HTTP example.
+All admin API requests must be authenticated by passing the API key as the 'X-Auth-Token' header to every HTTP request. You can verify that your API key works by using the following HTTP example.
 
 ```
 curl 'https://<your-backend>/admin' \
-  -H 'X-Auth-Token: <your-token>' \
+  -H 'X-Auth-Token: <your-api-key>' \
   -H 'Content-Type: application/json' \
   --data-binary '{"query":"{ getGQLSchema { schema } }"}'
 ```

--- a/content/admin/authentication.md
+++ b/content/admin/authentication.md
@@ -5,7 +5,7 @@ weight = 2
     parent = "slash-graphql-admin"
 +++
 
-Administrating your Dgraph Cloud with the (Slash CLI)[slash-cli/overview/], using the `/query`, `/mutate`, `/commit`, `/admin`, `/admin/slash`, or `/alter` endpoints on Dgraph Cloud, and bypassing Anonymous Access restrictions on the `/graphql` endpoint requires an API key. A new API key can be generated from Slash GraphQL by selecting the ["Settings" button](https://cloud.dgraph.io/_/settings) from the sidebar, then clicking the Add API Key button. Keep your API key safe, it will not be accessible once you leave the page.
+Administrating your Dgraph Cloud with the [Slash CLI](slash-cli/overview/), using the `/query`, `/mutate`, `/commit`, `/admin`, `/admin/slash`, or `/alter` endpoints on Dgraph Cloud, and bypassing Anonymous Access restrictions on the `/graphql` endpoint requires an API key. A new API key can be generated from Slash GraphQL by selecting the ["Settings" button](https://cloud.dgraph.io/_/settings) from the sidebar, then clicking the Add API Key button. Keep your API key safe, it will not be accessible once you leave the page.
 
 ![Slash-GraphQL: Add an API Key ](/images/slash-graphql-4.png)
 
@@ -15,7 +15,7 @@ There are two types of API keys, client and admin.
 - **Admin API keys** can be used to perform both client operations and admin operations like drop data, destroy backend, update schema.
 
 {{% notice "note" %}}
-Either Client API keys or Admin API keys can be used to bypass (Anonymous Access)[../settings] restrictions.
+Either Client API keys or Admin API keys can be used to bypass [Anonymous Access](../settings) restrictions.
 {{% /notice %}}
 
 ![Slash-GraphQL: Select API Key Role ](/images/slash-graphql-5.png)

--- a/content/admin/authentication.md
+++ b/content/admin/authentication.md
@@ -21,11 +21,11 @@ Either Client API keys or Admin API keys can be used to bypass [Anonymous Access
 ![Slash-GraphQL: Select API Key Role ](/images/slash-graphql-5.png)
 <br>
 <br>
-All admin API requests must be authenticated by passing the API key as the 'X-Auth-Token' header to every HTTP request. You can verify that your API key works by using the following HTTP example.
+All admin API requests must be authenticated by passing the API key as the 'Dg-Auth' header to every HTTP request. You can verify that your API key works by using the following HTTP example.
 
 ```
 curl 'https://<your-backend>/admin' \
-  -H 'X-Auth-Token: <your-api-key>' \
+  -H 'Dg-Auth: <your-api-key>' \
   -H 'Content-Type: application/json' \
   --data-binary '{"query":"{ getGQLSchema { schema } }"}'
 ```


### PR DESCRIPTION
On admin/authentication.md:
- Removed ambiguous phrase replacing with exact use cases.
- Renamed token -> key in this doc page to add clarity between JWT token and API key.
- Add notice about which keys can be used for Anonymous Access.
- Added links to Slash CLI and Anonymous Access doc pages.

On security.md
- Changed the h3 to have the exact phrase "Anonymous Access" to improve SEO and UX
- Described what effect the different configurations have.
- Added section concerning anonymous clients ability to still read and write to types if they are children of granted types
- Added example of setting both token and API Key with Apollo Client in React.