### PR TITLE
Fix 404 Links.

### DIFF
--- a/content/admin/authentication.md
+++ b/content/admin/authentication.md
@@ -5,7 +5,7 @@ weight = 2
     parent = "slash-graphql-admin"
 +++
 
-Administrating your Dgraph Cloud with the [Slash CLI](slash-cli/overview/), using the `/query`, `/mutate`, `/commit`, `/admin`, `/admin/slash`, or `/alter` endpoints on Dgraph Cloud, and bypassing Anonymous Access restrictions on the `/graphql` endpoint requires an API key. A new API key can be generated from Slash GraphQL by selecting the ["Settings" button](https://cloud.dgraph.io/_/settings) from the sidebar, then clicking the Add API Key button. Keep your API key safe, it will not be accessible once you leave the page.
+Administrating your Dgraph Cloud with the [Slash CLI](/slash-cli/overview/), using the `/query`, `/mutate`, `/commit`, `/admin`, `/admin/slash`, or `/alter` endpoints on Dgraph Cloud, and bypassing Anonymous Access restrictions on the `/graphql` endpoint requires an API key. A new API key can be generated from Slash GraphQL by selecting the ["Settings" button](https://cloud.dgraph.io/_/settings) from the sidebar, then clicking the Add API Key button. Keep your API key safe, it will not be accessible once you leave the page.
 
 ![Slash-GraphQL: Add an API Key ](/images/slash-graphql-4.png)
 
@@ -15,7 +15,7 @@ There are two types of API keys, client and admin.
 - **Admin API keys** can be used to perform both client operations and admin operations like drop data, destroy backend, update schema.
 
 {{% notice "note" %}}
-Either Client API keys or Admin API keys can be used to bypass [Anonymous Access](../settings) restrictions.
+Either Client API keys or Admin API keys can be used to bypass [Anonymous Access](/settings) restrictions.
 {{% /notice %}}
 
 ![Slash-GraphQL: Select API Key Role ](/images/slash-graphql-5.png)

--- a/content/admin/authentication.md
+++ b/content/admin/authentication.md
@@ -15,7 +15,7 @@ There are two types of API keys, client and admin.
 - **Admin API keys** can be used to perform both client operations and admin operations like drop data, destroy backend, update schema.
 
 {{% notice "note" %}}
-Either Client API keys or Admin API keys can be used to bypass [Anonymous Access](/settings) restrictions.
+Either Client API keys or Admin API keys can be used to bypass [Anonymous Access](/security) restrictions.
 {{% /notice %}}
 
 ![Slash-GraphQL: Select API Key Role ](/images/slash-graphql-5.png)

--- a/content/security.md
+++ b/content/security.md
@@ -13,7 +13,7 @@ To help secure your GraphQL API, Dgraph Cloud allows you to choose which GraphQL
 
 You can visit the [access tab on the schema page](https://cloud.dgraph.io/_/schema) and choose the operations that you want to allow/deny for anonymous users. 
 
-With Anonymous Access turned off, all GraphQL operations are restricted unless the client provides a valid [API Key](admin/authentication). With Anonymous Access turned on (Default configuration), you will have a button to "Edit Permissions"
+With Anonymous Access turned off, all GraphQL operations are restricted unless the client provides a valid [API Key](/admin/authentication). With Anonymous Access turned on (Default configuration), you will have a button to "Edit Permissions"
 
 In Edit Permissions, you will find options to turn on/off Anonymous Access to Lambda functions, custom Queries, and custom Mutations. For every Type defined in your GraphQL schema, Edit Permissions will show checkboxes to enable Anonymous Access to Read and Write. Checking Read will allow the anonymous end clients to access the `get<Type>` and `query<Type>` query operations. Checking Write will allow anonymous end clients to access the `add<Type>`, `update<Type>`, and `delete<Type>` mutation operations.
 


### PR DESCRIPTION
I had incorrectly set the links not putting prefixing with a `/` and pointed to a non existing page settings instead of security. Thank you.